### PR TITLE
overhaul of spec tests / general lesson flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Today we'll be giving the user the ability to create a new post in our BlogFlash
 require 'rails_helper'
 
 describe 'new post' do
-  it 'ensures that the form route works with new action' do
+  it 'ensures that the form route works with the /new action' do
     visit new_post_path
     expect(page.status_code).to eq(200)
   end
@@ -42,7 +42,7 @@ def new
 end
 ```
 
-Lastly, it says we're missing a template. Let's create `app/views/posts/new.html.erb`. Now that our routing test is passing, let's add a matcher spec to ensure that the form itself is being shown on the new post page:
+Lastly, it says we're missing a template. Let's create `app/views/posts/new.html.erb`. Now that our routing test is passing, let's add a matcher spec to ensure that the template is properly displaying HTML on the new post page:
 
 ```ruby
 # specs/features/post_spec.rb
@@ -53,9 +53,9 @@ describe 'new post' do
 
   ...
 
-  it 'has the form render with the new action' do
+  it 'renders HTML in the /new template' do
     visit new_post_path
-    expect(page).to have_content("Post Form")
+    expect(page).to have_content('Post Form')
   end
 end
 ```
@@ -80,7 +80,7 @@ describe 'new post' do
 
   ...
 
-  it "shows a new form that submits content and redirects to the index page, which now contains the submitted post's title and description" do
+  it "displays a new post form that redirects to the index page, which then contains the submitted post's title and description" do
     visit new_post_path
     fill_in 'post_title', with: 'My post title'
     fill_in 'post_description', with: 'My post description'

--- a/README.md
+++ b/README.md
@@ -3,21 +3,23 @@
 
 ## Rails Forms
 
-Welcome to the world of forms in Rails which will give users the ability to submit data into form fields. This can be used for: creating new database records, building a contact form, integrating a search engine field, and pretty much every other aspect of the application that requires user input. When it comes to forms in Rails you will discover that you will have the flexibility to utilize:
+Welcome to the world of Rails forms, which give users the ability to submit data into form fields. This can be used for: creating new database records, building a contact form, integrating a search engine field, and pretty much every other aspect of the application that requires user input. When it comes to forms in Rails, you will discover that you will have the flexibility to utilize:
 
-* Built in form helper methods
+* Built-in form helper methods
 
 * Plain HTML form elements
 
-This lesson is going to begin with integrating HTML form elements and then slowly start to refactor the form using Rails methods. It would be very easy to integrate form helpers (and we could have our form working in a few minutes), however, to fully understand what Rails is doing behind the scenes is more important than getting the form working right away. We're going to build the system from the ground up so when we're finished you should be able to understand all of the processes that are necessary in order to process forms in an application properly and securely.
+This lesson is going to begin by integrating HTML form elements and then slowly start refactoring the form using Rails methods. It would be very easy to integrate form helpers (and we could have our form working in a few minutes). However, fully understanding what Rails is doing behind the scenes is more important than getting the form working right away. We're going to build the system from the ground up. When we're finished, you should be able to understand all of the processes that are necessary in order to process forms in an application properly and securely.
 
 
 ## Rendering the form view
 
-Today we'll be giving the user the ability to create a new post in our BlogFlash application. Let's first create a Capybara spec to ensure that going to `posts/new` takes us to our form. If you remember back to the rails route helper lesson, we now know we don't need to hard code the route into our tests any longer. Let's use the standard RESTful convention of `new_post_path` for the route helper name:
+Today we'll be giving the user the ability to create a new post in our BlogFlash application. Let's first create a Capybara spec to ensure that going to `posts/new` takes us to our form. If you think back to the [Rails URL Helpers lesson](https://learn.co/lessons/rails-url-helpers-readme), we know that we don't need to hard-code the route into our tests any longer. Let's use the standard RESTful convention of `new_post_path` for the route helper name:
 
 ```ruby
 # specs/features/post_spec.rb
+
+require 'rails_helper'
 
 describe 'new post' do
   it 'ensures that the form route works with new action' do
@@ -27,25 +29,30 @@ describe 'new post' do
 end
 ```
 
-As expected this results in a failure saying that we don't have a `new_post_path` method, so let's create that in our route file:
+As expected, this results in a failure saying that we don't have a `new_post_path` method, so let's create that in our `routes.rb` file:
 
 ```ruby
 resources :posts, only: [:index, :new]
 ```
 
-Now it gives the failure `The action 'new' could not be found for PostsController`. To correct this, let's add a `new` action in the `post` controller:
+Now it gives this failure: `The action 'new' could not be found for PostsController`. To correct this, let's add a `new` action in `PostsController`:
 
 ```ruby
 def new
 end
 ```
 
-Lastly, it says we're missing a template. Let's add `app/views/posts/new.html.erb`. Now, all our tests are passing for our routing; let's add a matcher spec to make sure the form itself is being shown on this page:
+Lastly, it says we're missing a template. Let's create `app/views/posts/new.html.erb`. Now that our routing test is passing, let's add a matcher spec to ensure that the form itself is being shown on the new post page:
 
 ```ruby
 # specs/features/post_spec.rb
 
+require 'rails_helper'
+
 describe 'new post' do
+
+  ...
+
   it 'has the form render with the new action' do
     visit new_post_path
     expect(page).to have_content("Post Form")
@@ -53,47 +60,49 @@ describe 'new post' do
 end
 ```
 
-Running this spec gets a matcher error. We can get this passing by adding the HTML `<h3>Post Form</h3>` to the `new.html.erb` view template.
+Running this spec gets a matcher error. We can get this passing by adding `<h3>Post Form</h3>` to the `new.html.erb` view template.
 
 
 ## Building the form in HTML
 
-Our first pass at the form will be in plain HTML. In this reading we're not concerned with creating any records in the database, our focus is simply on the form process. We'll simply be printing out the submitted form params on the show page.
+Our first pass at the form will be in plain HTML. In this reading, we're not concerned with creating any records in the database. Our focus is on the form process. We'll simply be printing out the submitted form params on the show page.
 
 Let's create a spec for this. It's going to take a while for this to pass since we're going to be spending some time on the HTML creation process, but it's a good practice to ensure all new features are tested before the implementation code is added.
 
-As you are updating the code, make sure to test it out in the browser – don't just rely on the tests. It's important to see the errors in both the tests and the browser since you will want to become familiar with both types of failure messages.
+As you are updating the code, make sure to test it out in the browser – don't just rely on the tests. It's important to see the errors in both the tests and the browser since you'll want to become familiar with both types of failure messages.
 
 ```ruby
 # specs/features/post_spec.rb
 
-it 'shows a new form that submits content and redirects to new page and prints out params' do
-  visit new_post_path
+require 'rails_helper'
 
-  # The spec currently calls these fields "title"
-  # and "description" — you can change that for now,
-  # then change it back later after we refactor (this is
-  # a pretty common workflow — it's best to get used to it!)
-  fill_in 'post_title', with: "My post title"
-  fill_in 'post_description', with: "My post description"
+describe 'new post' do
 
-  click_on "Submit Post"
+  ...
 
-  expect(page).to have_content("My post title")
+  it "shows a new form that submits content and redirects to the index page, which now contains the submitted post's title and description" do
+    visit new_post_path
+    fill_in 'post_title', with: 'My post title'
+    fill_in 'post_description', with: 'My post description'
+
+    click_on 'Submit Post'
+
+    expect(page.current_path).to eq(posts_path)
+    expect(page).to have_content('My post title')
+    expect(page).to have_content('My post description')
+  end
 end
 ```
 
-This fails for obvious reasons. Let's follow the TDD process and let the failures help build our form. The first error says that it can't find the field `post_title`. Let's add the following HTML form items into the view template:
+This fails for obvious reasons. Let's follow the TDD process, letting the failures help build our form. The first error says that Capybara can't find the form field `post_title`. To fix that, let's create an HTML form in the `new.html.erb` view template:
 
-```ERB
-<h3>Post Form</h3>
-
+```erb
 <form>
   <label>Post title:</label><br>
-  <input type="text" id="post_title" name="post_title"><br>
+  <input type="text" id="post_title" name="post[title]"><br>
 
-  <label>Post Description</label><br>
-  <textarea id="post_description" name="post_description"></textarea><br>
+  <label>Post description:</label><br>
+  <textarea id="post_description" name="post[description]"></textarea><br>
 
   <input type="submit" value="Submit Post">
 </form>
@@ -101,53 +110,49 @@ This fails for obvious reasons. Let's follow the TDD process and let the failure
 <%= params.inspect %>
 ```
 
-We're using pretty standard conventions here:
+The `name` attributes in each `input` should look pretty familiar by now –– they're good ole' nested hashes. Just like Sinatra, Rails takes the user input entered into form fields and stores it in the `params` hash. The `name` attribute for a given `input` field is used as the key within `params` at which the entered data is stored. For instance, the input entered into the "Post title:" field in the above form would be stored as the value of `params[:post][:title]`. Traditionally, Rails apps use that `model[attribute]` syntax for `name` attributes (e.g., `post[title]`). We'll talk more about that in a later lesson.
 
-* `id` - This will have the model name followed by an underscore and then the attribute name
+You'll also notice that we're printing out `params` to the page. Until we set up the form action, clicking `Submit Post` won't actually redirect to a page on which the input values will be visible, but we'd still like to verify that the `params` hash is being populated correctly.
 
-* `name` - This is where Rails looks for the parameters and stores it in a params Hash. In a traditional Rails application this will be nested inside of the model with the syntax `model[attribute]`, however we will work through that in a later lesson.
+If we run the tests again, we'll see that Capybara expected submitting the form to redirect it to `/posts`, but instead it found itself back on `/posts/new`. Capybara was able to fill in the form elements and click `Submit Post`, but we need to update the form tag with an `action` attribute:
 
-You'll also notice that we're printing out the params to the page. This is because our Capybara tests will need to have the content rendered onto the page in order to pass. In a normal application, the page would redirect to a `show` or `index` page and this wouldn't be necessary.
-
-Okay, so the spec was able to fill in the form elements and submit, but it's giving an error because this form doesn't actually redirect to any page. Let's first update the form so that it has an action:
-
-```ERB
+```erb
 <form action="<%= posts_path %>">
 ```
 
-This will now redirect to `/posts`, however we also need to add a method so that the application knows that we are submitting form data via the POST HTTP verb:
+Now the form redirects to `/posts`. However, we also need to add a `method` attribute so that the application knows that we are submitting form data via the `POST` HTTP verb:
 
-```ERB
-<form action="<%= posts_path %>" method="post">
+```erb
+<form action="<%= posts_path %>" method="POST">
 ```
 
-If you open up the browser and try this you will get an error since the `create` route doesn't exist yet.
-
-Next, we need to draw a route so that the routing system knows what to do when a POST request is sent to the `/posts` resource:
+If you open up the browser and submit the form, you will get the following routing error: `No route matches [POST] "/posts"`. We need to draw a `create` route so that the routing system knows what to do when a `POST` request is sent to the `/posts` resource:
 
 ```ruby
+# config/routes.rb
+
 resources :posts, only: [:index, :new, :create]
 ```
 
-If you run rake routes, you will see we now have a ```posts#create``` action:
+If you run `rake routes`, you'll see we now have a `posts#create` action:
 
-```
-Prefix    Verb    URI                   Controller#Action
-posts     GET     /posts(.:format)      posts#index
-          POST    /posts(.:format)      posts#create
-new_post  GET     /posts/new(.:format)  posts#new
+```bash
+  Prefix Verb URI Pattern          Controller#Action
+   posts GET  /posts(.:format)     posts#index
+         POST /posts(.:format)     posts#create
+new_post GET  /posts/new(.:format) posts#new
 ```
 
-Now let's add in a `create` action in the posts' controller and have it grab the params, store them in an instance variable and then redirect to the new page (you can ignore how I'm passing the `@post` instance variable through the route, that is simply so the view can have access to the submitted form params):
+Running the spec tests again leads to an 'unknown action' error: `The action 'create' could not be found for PostsController`. Let's add a `create` action in `PostsController` and have it create a new `Post` object with the values from `params` and then redirect to the index page:
 
 ```ruby
 def create
-  @post = params
-  redirect_to new_post_path(post: @post)
+  Post.create(title: params[:post][:title], description: params[:post][:description])
+  redirect_to posts_path
 end
 ```
 
-If you run the rails server and go to the `posts/new` page and fill in the title and description form elements and click submit you will find a new type of error:
+If you run the Rails server, navigate to the `posts/new` page, fill in the title and description form elements, and click submit, you will find a new type of error:
 
 ![InvalidAuthenticityToken](https://s3.amazonaws.com/flatiron-bucket/readme-lessons/InvalidAuthenticityToken.png)
 
@@ -156,28 +161,26 @@ Which leads us to a very important part of Rails forms: CSRF.
 
 ## What is CSRF?
 
-"CSRF" stands for: Cross-Site Request Forgery. Instead of giving a boring explanation of what happens during a CSRF request, let's walk through a real life example of a Cross-Site Request Forgery hack:
+"CSRF" stands for: Cross-Site Request Forgery. Instead of giving a boring explanation of what happens during a CSRF request, let's walk through a real-life example of a Cross-Site Request Forgery hack:
 
-1. You go to your bank website and login; you check your balance and then open up a new tab in the browser and go to your favorite meme site.
+1. You go to your bank website and log in. After checking your balance, you open up a new tab in the browser and go to your favorite meme site.
 
-2. Without you knowing, the meme site is actually a hacking site that has scripts running in the background as soon as you land on their page.
+2. Unbeknownst to you, the meme site is actually a hacking site that has scripts running in the background as soon as you land on their page.
 
-3. One of the scripts on the site hijacks the banking session that you have open in the other browser and submits a form request to transfer money to their account.
+3. One of the scripts on the site hijacks the banking session that's open in the other browser tab and submits a form request to transfer money to their account.
 
 4. The banking form can't tell that the form request wasn't made by you, so it goes through the process as if you were the one who made the request.
 
-This is a Cross-Site Request Forgery request; one site makes a request to another site via a form. Rails blocks this from happening by default by requiring that a unique authenticity token is submitted with each form. This authenticity token is stored in the session and can't be hijacked by hackers since it performs a match check when the form is submitted and will throw an error if the token isn't there or doesn't match.
+One site making a request to another site via a form is the general flow of a Cross-Site Request Forgery. Rails blocks this from happening by default by requiring that a unique authenticity token be submitted with each form. This authenticity token is stored in the session and can't be hijacked by hackers: it performs a match check when the form is submitted, and it will throw an error if the token isn't there or doesn't match.
 
-To fix this `ActionController::InvalidAuthenticityToken` error we can integrate the `form_authenticity_token` helper into the form as a hidden field:
+To fix this `ActionController::InvalidAuthenticityToken` error, we can integrate the `form_authenticity_token` helper into the form as a hidden field:
 
-```ERB
-<h3>Post Form</h3>
-
-<form action="<%= posts_path %>" method="post">
+```erb
+<form action="<%= posts_path %>" method="POST">
   <label>Post title:</label><br>
   <input type="text" id="post_title" name="post[title]"><br>
 
-  <label>Post Description</label><br>
+  <label>Post description:</label><br>
   <textarea id="post_description" name="post[description]"></textarea><br>
 
   <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>">
@@ -185,82 +188,84 @@ To fix this `ActionController::InvalidAuthenticityToken` error we can integrate 
 </form>
 ```
 
-If you refresh the page you will see that not only is the error fixed, but the elements are now also being printed out on the page! Running the specs you will see that our spec is now passing, so our form is working. However, this might be one of the ugliest Rails forms I've ever seen, so let's do some re-factoring.
+If we refresh the `posts/new` page, fill out the form, and click `Submit Post`, the browser should load the index view with our newly-created post's title and description in a bulleted list. All of the spec tests should now be passing, and our form is functional. However, this is probably one of the ugliest and least-elegant Rails forms that has ever existed, so let's do some refactoring.
 
 
 ## Using form helpers
 
-The `ActionView` has a number of methods we can use to streamline our form. What's `ActionView`? `ActionView` is a sub-gem of Rails that has a number of helper methods that we can use in a Rails application that assist with streamlining view template code. Let's start by integrating a Rails `form_tag` element:
+`ActionView`, a sub-gem of Rails, provides a number of helper methods to assist with streamlining view template code. Specifically, we can use `ActionView` methods to improve our form! Let's start by integrating a Rails `form_tag` element:
 
-```ERB
+```erb
 <%= form_tag posts_path do %>
   <label>Post title:</label><br>
   <input type="text" id="post_title" name="post[title]"><br>
 
-  <label>Post Description</label><br>
+  <label>Post description:</label><br>
   <textarea id="post_description" name="post[description]"></textarea><br>
+
+  <input type="hidden" name="authenticity_token" value="<%= form_authenticity_token %>">
+  <input type="submit" value="Submit Post">
+<% end %>
+```
+
+Next, we'll replace that hidden authenticity token input field with a Rails `hidden_field_tag`:
+
+```erb
+<%= form_tag posts_path do %>
+
+  ...
 
   <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
   <input type="submit" value="Submit Post">
 <% end %>
 ```
 
-Running the tests you will see that all of the tests are still passing. If you go and look at the HTML that this generates you will see the following:
+If we run the tests again, we'll see that they're all still passing. Let's take a look at the HTML generated by our Rails `ActionView` methods:
 
 ```html
-<form action="/posts" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="7B5m/x8roxG6bc1vbRxRhr/z+ql6D261+j6LwHeGjeial7hxyW+5zk6CTGLpY1aKUj9hzLPdtRhWfcX5i047Iw==" />
+<form action="/posts" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="zkOjrjTG8Lxn0CF8Lt/kFIgWdYyY3NTMbwh+Q9kPX1NrYztgq0GZNCjLFavBXka1Y5QhNjDlhX+dzQoZMzUjOA==" />
   <label>Post title:</label><br>
   <input type="text" id="post_title" name="post[title]"><br>
 
-  <label>Post Description</label><br>
+  <label>Post description:</label><br>
   <textarea id="post_description" name="post[description]"></textarea><br>
 
-  <input type="hidden" name="authenticity_token" id="authenticity_token" value="JC6cMiNK9k8nuWJdKp/3E29C/bALDkK9N6it3TeFEb1Sp0K89Q7skNNW41Cu4PAfgo5m1cLcmRCb6+Pky02ndg==" />
+  <input type="hidden" name="authenticity_token" id="authenticity_token" value="7SuubeJGbqfm4rO+F5VTS6Wl1SNCTGOr/mrYZKOQLbtICzajfcEHL6n5h2n4FPHqTieBmep1MhgMr6w+SapR0A==" />
   <input type="submit" value="Submit Post">
 </form>
 ```
 
-The `form_tag` Rails helper is smart enough to know that we want to pass the form params using the POST method and it automatically renders the HTML that we were writing by hand before.
+The `form_tag` Rails helper is smart enough to know that we want to submit the form via the `POST` method, and it automatically renders the HTML that we were writing by hand before. The `form_tag` method also automatically generates the necessary authenticity token, so we can remove the now-redundant `hidden_field_tag`.
 
-Now let's integrate some other form helpers to let Rails generate the input elements for us, for this form we'll be using the `text_field_tag` and `text_area_tag` tag and pass them the attributes with symbols. It's important to realize that form helpers aren't magic, they are simply Ruby methods that have arguments, which are the inputs and additional parameters related to the form elements. In addition to updating the form fields, we'll also replace the HTML tag for the submit button with the `submit_tag`. Lastly, we can remove the manual authenticity token call since that is generated automatically through the `form_tag` helper:
+Next, let's integrate some other form helpers to let Rails generate the input elements for us. For this form, we'll be using a `text_field_tag` and a `text_area_tag` and passing each the corresponding `name` attribute as a symbol. It's important to keep in mind that form helpers aren't magic –– they're simply Ruby methods that accept arguments, such as the `name` attribute and any additional parameters related to the form's elements. In addition to updating the form fields, we'll also replace the HTML tag for the submit button with a `submit_tag`.
 
-```ERB
+```erb
 <%= form_tag posts_path do %>
   <label>Post title:</label><br>
-  <%= text_field_tag :title %><br>
+  <%= text_field_tag :'post[title]' %><br>
 
-  <label>Post Description</label><br>
-  <%= text_area_tag :description %><br>
+  <label>Post description:</label><br>
+  <%= text_area_tag :'post[description]' %><br>
 
   <%= submit_tag "Submit Post" %>
 <% end %>
 ```
 
-So what HTML does this generate for us? Below is the raw HTML:
+Let's check out the raw HTML all these helper methods generate for us:
 
-```HTML
-<form action="/posts" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="uQUOmh8edu8S/x5mVqp4aMpqEkHGbBYCdY6NVrvBut7PjNAUyVpsMOYQn2vS1X9kJ6aJJA++za/ZzcNvRwkMFQ==" />
+```html
+<form action="/posts" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="vq9SMVNk0CjwgZmYomFRhwbo5dfu7tI/2FiR7jOtlVgbj8r/zOO5oL+arU9N4PMm7WqxbUbXg4wqneW02ZfpMw==" />
   <label>Post title:</label><br>
-  <input type="text" name="title" id="title" /><br>
+  <input type="text" name="post[title]" id="post_title" /><br>
 
-  <label>Post Description</label><br>
-  <textarea name="description" id="description"></textarea><br>
+  <label>Post description:</label><br>
+  <textarea name="post[description]" id="post_description">
+</textarea><br>
 
   <input type="submit" name="commit" value="Submit Post" />
 </form>
 ```
 
-Notice how the `name` and `id` elements are different from what we needed to use when we manually built out the form. By utilizing the form tag helpers, Rails streamlined the naming structure for the `name` and `id` values since we were able to simply provide a symbol of the attribute the input was associated with.
-
-This is all working on the page, however it broke some of our tests since it streamlined the ID attribute in the form, so let's update our spec:
-
-```ruby
-fill_in 'title', with: "My post title"
-fill_in 'description', with: "My post description"
-```
-
-Running the specs again and now we're back to everything passing and you now know how to build a Rails form from scratch and refactor it using Rails form helper methods, nice work!
-
-<a href='https://learn.co/lessons/rails-form_tag-readme' data-visibility='hidden'>View this lesson on Learn.co</a>
+Run the spec tests one last time to verify that everything is still passing. You now know how to build a Rails form from scratch and refactor it using Rails form helper methods. Nice work!
 
 <p class='util--hide'>View <a href='https://learn.co/lessons/rails-form_tag-readme'>Rails form_tag</a> on Learn.co and start learning to code for free.</p>

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,3 +1,6 @@
 class PostsController < ApplicationController
-
+  def index
+    @posts = Post.all
+  end
+  
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,5 @@
+<ul>
+  <% @posts.each do |p| %>
+    <li><%= p.title %> - <%= p.description %></li>
+  <% end %>
+</ul>

--- a/spec/features/post_spec.rb
+++ b/spec/features/post_spec.rb
@@ -1,24 +1,5 @@
 require 'rails_helper'
 
 describe 'new post' do
-  it 'ensures that the form route works with new action' do
-    visit new_post_path
-    expect(page.status_code).to eq(200)
-  end
 
-  it 'has the form render with the new action' do
-    visit new_post_path
-    expect(page).to have_content("Post Form")
-  end
-
-  it 'shows a new form that submits content and redirects to new page and prints out params' do
-    visit new_post_path
-
-    fill_in 'title', with: "My post title"
-    fill_in 'description', with: "My post description"
-
-    click_on "Submit Post"
-
-    expect(page).to have_content("My post title")
-  end
 end


### PR DESCRIPTION
* redirect `create` action to the `index` action instead of the `new` action –– this is the first intro to `create`, and I think it's a good idea to follow a more standard Rails flow
* add RSpec expectations
* clear out `post_spec.rb` file to allow students to build it as they progress through the lesson (fixed: https://github.com/learn-co-curriculum/rails-form_tag-readme/issues/12)
* clean up the `name` attributes used in `input` fields and the corresponding descriptions, all of which was a bit unnecessary (fixed: https://github.com/learn-co-curriculum/rails-form_tag-readme/issues/11)